### PR TITLE
Fix Stretched Images in member card

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -427,9 +427,10 @@ input[type="radio"] {
 }
 
 .card-img {
-  border-radius: 50%;
-  margin-bottom: 20px;
-  height: 120px;
+  border-radius: 50%; 
+  object-fit: cover; 
+  width: 150px; 
+  height: 150px; 
 }
 
 .card-title {


### PR DESCRIPTION
In the member card section, an issue was observed where the member photos were displaying with improper proportions, resulting in unwanted stretching. To rectify this, I made necessary CSS adjustments to ensure that the images are now presented in a manner that maintains their original aspect ratio, providing a clean and visually pleasing appearance.